### PR TITLE
Add a dump method as the inverse of update

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 0.2.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added a ``dump`` method to get all the fields in bulk.
 
 
 0.2.3 (2017-09-14)

--- a/pypom_form/meta.py
+++ b/pypom_form/meta.py
@@ -57,6 +57,10 @@ class PyPOMFormMixin(object):
 
         return self
 
+    def dump(self):
+        """ Dumps all fields. """
+        return {key: getattr(self, key) for key in self.__pypom__.keys()}
+
     def raw_update(self, **raw_values):
         """ Bulk page update with chained calls support.
             Updates fields with raw values (not deserialized)


### PR DESCRIPTION
Used a fake widget class rather than mocking multiple getters in tests.